### PR TITLE
Update to 4.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,4 @@
 nodejs_nodesource_pin_priority: 500
 
 # 0.10 or 0.12 or 4.x
-nodejs_version: "4.3"
+nodejs_version: "4.4"


### PR DESCRIPTION
I ran this role on a fresh VM tonight and it broke because 4.3 is gone from the NodeSource Debian repo. Switching to 4.4 fixed the issue.
